### PR TITLE
Changes in Internationalization message

### DIFF
--- a/restful-web-servicess/src/main/java/com/rest/webservice/restfulwebservicess/RestfulWebServicessApplication.java
+++ b/restful-web-servicess/src/main/java/com/rest/webservice/restfulwebservicess/RestfulWebServicessApplication.java
@@ -6,9 +6,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 @SpringBootApplication
 @ComponentScan(basePackages = "com.rest.webservices.restfulwebservices.helloworld")
@@ -20,15 +19,10 @@ public class RestfulWebServicessApplication {
 
 	@Bean
 	public LocaleResolver localeResolvers() {
-		SessionLocaleResolver localeResolver = new SessionLocaleResolver();
+
+		AcceptHeaderLocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
 		localeResolver.setDefaultLocale(Locale.US);
 		return localeResolver;
 	}
 
-	@Bean(name = "messageSource")
-	public ResourceBundleMessageSource bundleMessageSource() {
-		ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-		messageSource.setBasename("messages");
-		return messageSource;
-	}
 }

--- a/restful-web-servicess/src/main/java/com/rest/webservices/restfulwebservices/helloworld/HelloContoler.java
+++ b/restful-web-servicess/src/main/java/com/rest/webservices/restfulwebservices/helloworld/HelloContoler.java
@@ -1,12 +1,10 @@
 package com.rest.webservices.restfulwebservices.helloworld;
 
-import java.util.Locale;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,8 +30,8 @@ public class HelloContoler {
 	}
 
 	@GetMapping(path = "/hello-world-internationalized")
-	public String helloWorldInternationalized(
-			@RequestHeader(name = "Accept-Language", required = false) Locale locale) {
-		return messageSource.getMessage("good.morning.message", null, locale);
+	public String helloWorldInternationalized() {
+		return messageSource.getMessage("good.morning.message", null, LocaleContextHolder.getLocale());
 	}
+
 }

--- a/restful-web-servicess/src/main/resources/application.properties
+++ b/restful-web-servicess/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 server.port=9853
 #logging.level.org.springframework=debug
 spring.jackson.serialization.write-dates-with-zone-id=false
+spring.messages.basename=messages


### PR DESCRIPTION
@Bean
	public LocaleResolver localeResolvers() {
		AcceptHeaderLocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
		localeResolver.setDefaultLocale(Locale.US);
		return localeResolver;
	}
Instead of "SessionLocaleResolver" what we can use is AcceptHeaderLocaleResolver  because we are sending the accept language in postman header.

@Bean(name = "messageSource")
	public ResourceBundleMessageSource bundleMessageSource() {
		ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
		messageSource.setBasename("messages");
		return messageSource;
Here witout using this we can use we can use

spring.messages.basename=messages
in application.properties

@RequestHeader(name = "Accept-Language", required = false) Locale locale
Without using RequestHeader we can use LocaleContextHolder.getLocale()
in get message
		return messageSource.getMessage("good.morning.message", null, LocaleContextHolder.getLocale());