### PR TITLE
Add Actuator and HAL browser

### DIFF
--- a/restful-web-servicess/pom.xml
+++ b/restful-web-servicess/pom.xml
@@ -33,6 +33,14 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-rest-hal-browser</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
 			<version>2.4.0</version>

--- a/restful-web-servicess/src/main/resources/application.properties
+++ b/restful-web-servicess/src/main/resources/application.properties
@@ -2,3 +2,4 @@ server.port=9853
 #logging.level.org.springframework=debug
 spring.jackson.serialization.write-dates-with-zone-id=false
 spring.messages.basename=messages
+management.endpoints.web.exposure.include=*


### PR DESCRIPTION
**### Add Actuator and HAL browser**
**It provides a loat of monitoring facilitees around us visas and
what we would also want to be able to do is to look at the services which are proved
Add Actuator dependancy**
_<dependency>
			<groupId>org.springframework.boot</groupId>
			<artifactId>spring-boot-starter-actuator</artifactId>
		</dependency>_
**To look at the services which are provided we actuator in a browser so we add
"spring-data-rest-hal-browser" depenancy**
_<dependency>
			<groupId>org.springframework.data</groupId>
			<artifactId>spring-data-rest-hal-browser</artifactId>
		</dependency>_
**### INFO:-**
**To Add ifo we need configure our application property there is a lot of stuff that actuator providedes to enable that we would need to configure property**

> The way we can do by using  "management.endpoints.web.exposure.include=*"
**### URL LUNCH THE ACTUATOR**

> `_http://localhost:9853/browser/index.html#/actuator_`
> `_http://localhost:9853/actuator_`
